### PR TITLE
Add workflow for stack-nightly

### DIFF
--- a/.github/workflows/stackage-nightly.yml
+++ b/.github/workflows/stackage-nightly.yml
@@ -1,0 +1,29 @@
+name: stackage-nightly
+
+on:
+  schedule:
+    - cron: '5 6 * * *'
+  push:
+    branches:
+      - feature/nightly
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1  
+    
+    - name: Install system dependencies 
+      run: |
+        sudo apt-get install libxml2-dev
+
+    - name: Install the Haskell Stack 
+      run: |
+        mkdir -p ~/.local/bin
+        curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+
+    - name: Build with the nightly snapshot
+      run: |
+        rm -f stack.yaml && stack init --resolver nightly
+        stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

--- a/.github/workflows/stackage-nightly.yml
+++ b/.github/workflows/stackage-nightly.yml
@@ -3,9 +3,6 @@ name: stackage-nightly
 on:
   schedule:
     - cron: '5 6 * * *'
-  push:
-    branches:
-      - feature/nightly
 
 jobs:
   build:


### PR DESCRIPTION
This PR adds a second GitHub Actions workflow which runs every morning using the latest `nightly` Stack resolver to check for issues.