### PR TITLE
Avoid unsafeUseAsCString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix non-determistic incorrect output with respect to nsPrefixes ([#3](https://github.com/mbg/c14n/pulls/3) by [@fumieval](https://github.com/fumievak))
+
 # 0.1.0
 
 * Initial release


### PR DESCRIPTION
This change fixes the test failures on mbg/wai-saml2#52 . It turns out that the use of `unsafeAsCString` causes `nsPrefixes` to be effectively empty most of the time (yes, it is __non-deterministic__!)

I confirmed that the tests above with this patch pass on lts-19.33 or older.

I suggest to release the fix in an urgent manner.